### PR TITLE
Inject java 9 flags to Takipi Agent

### DIFF
--- a/docs/framework-takipi_agent.md
+++ b/docs/framework-takipi_agent.md
@@ -36,6 +36,15 @@ The framework can be configured by modifying the [`config/takipi_agent.yml`][] f
 | `node_name_prefix` | Node name prefix, will be concatenated with `-` and instance index
 | `application_name` | Override the CloudFoundry default application name
 
+### Remarks
+In case **Java 9+** is being used, 2 JVM flags will be added to the execution:
+| Name | Description
+| ---- | -----------
+| `-XX:-UseTypeSpeculation` | Disable type speculation optimization of the JVM which might not work properly in some situations where an agent is present.
+| `-Xshare:off` | Disable class sharing as it might affect the agent's bytecode manipulation work.
+
+These two flags are needs as otherwise the agent or the JVM might not work properly together.
+
 ## Logs
 
 Currently, you can get the Takipi agent logs using `cf files` command:

--- a/lib/java_buildpack/framework/takipi_agent.rb
+++ b/lib/java_buildpack/framework/takipi_agent.rb
@@ -39,6 +39,8 @@ module JavaBuildpack
                 .add_agentpath(agent)
                 .add_system_property('takipi.name', application_name)
 
+        update_java9
+
         @droplet.environment_variables
                 .add_environment_variable('LD_LIBRARY_PATH',
                                           "$LD_LIBRARY_PATH:#{qualify_path(lib, @droplet.root)}")
@@ -97,6 +99,14 @@ module JavaBuildpack
 
       def node_name
         "#{@configuration['node_name_prefix']}-$CF_INSTANCE_INDEX"
+      end
+
+      def update_java9
+        return unless @droplet.java_home.java_9_or_later?
+
+        @droplet.java_opts
+                .add_system_property('-Xshare:off')
+                .add_system_property('-XX:-UseTypeSpeculation')
       end
 
     end


### PR DESCRIPTION
- Updated the documentation
- Inject Java 9+ flags when using the Takipi agent